### PR TITLE
Check if current server entry is not null

### DIFF
--- a/src/client/java/com/holebois/client_maps/client_mapsClient.java
+++ b/src/client/java/com/holebois/client_maps/client_mapsClient.java
@@ -30,7 +30,7 @@ public class client_mapsClient implements ClientModInitializer {
 
 	public static byte[] getMap(Integer mapId) {
         client = MinecraftClient.getInstance();
-        if (client.isInSingleplayer()) {
+        if (client.isInSingleplayer() || client.getCurrentServerEntry() == null) {
             return null;
         }
         File save_dir = new File(client.runDirectory, ".client_maps");


### PR DESCRIPTION
This should prevent crashes while using Replay Mod:
```
java.lang.NullPointerException: Cannot read field "field_3761" because the return value of "net.minecraft.class_310.method_1558()" is null
	at com.holebois.client_maps.client_mapsClient.getMap(client_mapsClient.java:34)
	at net.minecraft.class_1806.handler$bjc000$client_maps$getMapState(class_1806.java:539)
	at net.minecraft.class_1806.method_7997(class_1806.java:60)
	...
```
I didn't test this though